### PR TITLE
cargo: rename package for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xenstore"
+name = "xenstore-rs"
 version = "0.2.0"
 authors = ["Mathieu Tarral <mathieu.tarral@protonmail.com>"]
 edition = "2018"


### PR DESCRIPTION
I'm renaming the package from `xenstore` to `xenstore-rs` as the name is available on crates.io