### PR TITLE
Implement writing data to xenstore

### DIFF
--- a/examples/xenstore-cli.rs
+++ b/examples/xenstore-cli.rs
@@ -20,6 +20,13 @@ enum Command {
         #[arg()]
         path: String,
     },
+    /// Write value to Xenstore path
+    Write {
+        #[arg()]
+        path: String,
+        #[arg()]
+        data: String,
+    },
 }
 
 fn main() {
@@ -31,6 +38,7 @@ fn main() {
     match cli.command {
         Command::List{path} => cmd_list(&xs, &path),
         Command::Read{path} => cmd_read(&xs, &path),
+        Command::Write{path, data} => cmd_write(&xs, &path, &data),
     }
 }
 
@@ -46,4 +54,9 @@ fn cmd_read(xs: &Xs, path: &String) {
     let value = xs.read(XBTransaction::Null, &path)
         .expect("path should be readable");
     println!("{}", value);
+}
+
+fn cmd_write(xs: &Xs, path: &String, data: &String) {
+    xs.write(XBTransaction::Null, &path, &data)
+        .expect("cannot write to xenstore path");
 }

--- a/examples/xenstore-cli.rs
+++ b/examples/xenstore-cli.rs
@@ -20,6 +20,11 @@ enum Command {
         #[arg()]
         path: String,
     },
+    /// Remove value of Xenstore path
+    Rm {
+        #[arg()]
+        path: String,
+    },
     /// Write value to Xenstore path
     Write {
         #[arg()]
@@ -38,6 +43,7 @@ fn main() {
     match cli.command {
         Command::List{path} => cmd_list(&xs, &path),
         Command::Read{path} => cmd_read(&xs, &path),
+        Command::Rm{path} => cmd_rm(&xs, &path),
         Command::Write{path, data} => cmd_write(&xs, &path, &data),
     }
 }
@@ -54,6 +60,11 @@ fn cmd_read(xs: &Xs, path: &String) {
     let value = xs.read(XBTransaction::Null, &path)
         .expect("path should be readable");
     println!("{}", value);
+}
+
+fn cmd_rm(xs: &Xs, path: &String) {
+    xs.rm(XBTransaction::Null, &path)
+        .expect("cannot rm xenstore path");
 }
 
 fn cmd_write(xs: &Xs, path: &String, data: &String) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,17 @@ impl Xs {
         }
     }
 
+    pub fn rm(&self, transaction: XBTransaction, path: &str) -> Result<(), IoError> {
+        let c_path = CString::new(path).unwrap();
+        let trans_value = transaction.to_u32().expect("Invalid transaction value");
+        let res = (self.libxenstore.rm)(self.handle, trans_value, c_path.as_ptr());
+        if res {
+            Ok(())
+        } else {
+            Err(IoError::last_os_error())
+        }
+    }
+
     fn close(&mut self) {
         (self.libxenstore.close)(self.handle);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 mod libxenstore;
 
+use std::convert::TryFrom;
 use std::error::Error;
 use std::ffi::{c_void, CStr, CString};
 use std::io::Error as IoError;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_uint};
 use std::slice;
 
 #[macro_use]
@@ -83,6 +84,22 @@ impl Xs {
                 libc::free(res);
                 Ok(res_string)
             }
+        }
+    }
+
+    pub fn write(&self, transaction: XBTransaction, path: &str, data: &str
+    ) -> Result<(), IoError> {
+        let char_data = data.as_bytes();
+        let len: c_uint = c_uint::try_from(char_data.len())
+            .expect("Too much data");
+        let c_path = CString::new(path).unwrap();
+        let trans_value = transaction.to_u32().expect("Invalid transaction value");
+        let res = (self.libxenstore.write)(self.handle, trans_value, c_path.as_ptr(),
+                                           char_data.as_ptr() as *const c_void, len);
+        if res {
+            Ok(())
+        } else {
+            Err(IoError::last_os_error())
         }
     }
 

--- a/src/libxenstore.rs
+++ b/src/libxenstore.rs
@@ -25,6 +25,14 @@ type FnRead = fn(
     path: *const c_char,
     len: *mut c_uint,
 ) -> *mut c_void;
+// xs_write
+type FnWrite = fn(
+    h: *mut xs_handle,
+    t: xs_transaction_t,
+    path: *const c_char,
+    data: *const c_void,
+    len: c_uint,
+) -> bool;
 
 #[derive(Debug)]
 pub struct LibXenStore {
@@ -33,6 +41,7 @@ pub struct LibXenStore {
     pub close: RawSymbol<FnClose>,
     pub directory: RawSymbol<FnDirectory>,
     pub read: RawSymbol<FnRead>,
+    pub write: RawSymbol<FnWrite>,
 }
 
 impl LibXenStore {
@@ -53,12 +62,16 @@ impl LibXenStore {
         let read_sym: Symbol<FnRead> = lib.get(b"xs_read\0")?;
         let read = read_sym.into_raw();
 
+        let write_sym: Symbol<FnWrite> = lib.get(b"xs_write\0")?;
+        let write = write_sym.into_raw();
+
         Ok(LibXenStore {
             _lib: lib,
             open,
             close,
             directory,
             read,
+            write,
         })
     }
 }

--- a/src/libxenstore.rs
+++ b/src/libxenstore.rs
@@ -25,6 +25,12 @@ type FnRead = fn(
     path: *const c_char,
     len: *mut c_uint,
 ) -> *mut c_void;
+// xs_rm
+type FnRm = fn(
+    h: *mut xs_handle,
+    t: xs_transaction_t,
+    path: *const c_char,
+) -> bool;
 // xs_write
 type FnWrite = fn(
     h: *mut xs_handle,
@@ -41,6 +47,7 @@ pub struct LibXenStore {
     pub close: RawSymbol<FnClose>,
     pub directory: RawSymbol<FnDirectory>,
     pub read: RawSymbol<FnRead>,
+    pub rm: RawSymbol<FnRm>,
     pub write: RawSymbol<FnWrite>,
 }
 
@@ -62,6 +69,9 @@ impl LibXenStore {
         let read_sym: Symbol<FnRead> = lib.get(b"xs_read\0")?;
         let read = read_sym.into_raw();
 
+        let rm_sym: Symbol<FnRm> = lib.get(b"xs_rm\0")?;
+        let rm = rm_sym.into_raw();
+
         let write_sym: Symbol<FnWrite> = lib.get(b"xs_write\0")?;
         let write = write_sym.into_raw();
 
@@ -71,6 +81,7 @@ impl LibXenStore {
             close,
             directory,
             read,
+            rm,
             write,
         })
     }


### PR DESCRIPTION
This PR includes support for `xs_write` and `xs_rm`, driven by [implementation of a prototype guest agent](https://gitlab.com/ydirson/xen-guest-agent/-/tree/ydi/rust-proto)
Note: this PR builds on #9, delta for this PR is https://github.com/xcp-ng/xenstore-rs/compare/tool...xcp-ng:xenstore-rs:xs_write