### PR TITLE
libloading: force to load libxenstore.so.4

### DIFF
--- a/src/libxenstore.rs
+++ b/src/libxenstore.rs
@@ -1,12 +1,13 @@
 use std::os::raw::{c_char, c_uint, c_ulong, c_void};
 
+use std::ffi::OsString;
 use xenstore_sys::{xs_handle, xs_transaction_t};
 
 use libloading::os::unix::Symbol as RawSymbol;
-use libloading::{library_filename, Error, Library, Symbol};
+use libloading::{Error, Library, Symbol};
 use log::info;
 
-const LIBXENSTORE_BASENAME: &str = "xenstore";
+const LIBXENSTORE_BASENAME: &str = "libxenstore.so.4";
 // xs_open
 type FnOpen = fn(flags: c_ulong) -> *mut xs_handle;
 // xs_close
@@ -49,7 +50,7 @@ pub struct LibXenStore {
 
 impl LibXenStore {
     pub unsafe fn new() -> Result<Self, Error> {
-        let lib_filename = library_filename(LIBXENSTORE_BASENAME);
+        let lib_filename: OsString = LIBXENSTORE_BASENAME.into();
         info!("Loading {}", lib_filename.to_str().unwrap());
         let lib = Library::new(lib_filename)?;
         // load symbols

--- a/src/libxenstore.rs
+++ b/src/libxenstore.rs
@@ -7,7 +7,8 @@ use libloading::os::unix::Symbol as RawSymbol;
 use libloading::{Error, Library, Symbol};
 use log::info;
 
-const LIBXENSTORE_BASENAME: &str = "libxenstore.so.4";
+const LIBXENSTORE_SONAME_LIST: [&str; 2] = ["3.0", "4"];
+const LIBXENSTORE_BASENAME: &str = "libxenstore.so.";
 // xs_open
 type FnOpen = fn(flags: c_ulong) -> *mut xs_handle;
 // xs_close
@@ -49,37 +50,50 @@ pub struct LibXenStore {
 }
 
 impl LibXenStore {
+    /// Loads the libxenstore.so library dynamically, by trying multiple SONAMES
+    /// On failure it returns the last load error
     pub unsafe fn new() -> Result<Self, Error> {
-        let lib_filename: OsString = LIBXENSTORE_BASENAME.into();
-        info!("Loading {}", lib_filename.to_str().unwrap());
-        let lib = Library::new(lib_filename)?;
-        // load symbols
-        let open_sym: Symbol<FnOpen> = lib.get(b"xs_open\0")?;
-        let open = open_sym.into_raw();
+        let mut last_load_error: Option<Error> = None;
+        for soname in LIBXENSTORE_SONAME_LIST {
+            let lib_filename = format!("{}.{}", LIBXENSTORE_BASENAME, soname);
+            info!("Loading {}", lib_filename);
+            let result = Library::new::<OsString>(lib_filename.clone().into());
+            if let Err(err) = result {
+                info!("Failed to load {}", lib_filename);
+                last_load_error = Some(err);
+                continue;
+            } else {
+                let lib = result.unwrap();
+                // load symbols
+                let open_sym: Symbol<FnOpen> = lib.get(b"xs_open\0")?;
+                let open = open_sym.into_raw();
 
-        let close_sym: Symbol<FnClose> = lib.get(b"xs_close\0")?;
-        let close = close_sym.into_raw();
+                let close_sym: Symbol<FnClose> = lib.get(b"xs_close\0")?;
+                let close = close_sym.into_raw();
 
-        let directory_sym: Symbol<FnDirectory> = lib.get(b"xs_directory\0")?;
-        let directory = directory_sym.into_raw();
+                let directory_sym: Symbol<FnDirectory> = lib.get(b"xs_directory\0")?;
+                let directory = directory_sym.into_raw();
 
-        let read_sym: Symbol<FnRead> = lib.get(b"xs_read\0")?;
-        let read = read_sym.into_raw();
+                let read_sym: Symbol<FnRead> = lib.get(b"xs_read\0")?;
+                let read = read_sym.into_raw();
 
-        let rm_sym: Symbol<FnRm> = lib.get(b"xs_rm\0")?;
-        let rm = rm_sym.into_raw();
+                let rm_sym: Symbol<FnRm> = lib.get(b"xs_rm\0")?;
+                let rm = rm_sym.into_raw();
 
-        let write_sym: Symbol<FnWrite> = lib.get(b"xs_write\0")?;
-        let write = write_sym.into_raw();
+                let write_sym: Symbol<FnWrite> = lib.get(b"xs_write\0")?;
+                let write = write_sym.into_raw();
 
-        Ok(LibXenStore {
-            _lib: lib,
-            open,
-            close,
-            directory,
-            read,
-            rm,
-            write,
-        })
+                return Ok(LibXenStore {
+                    _lib: lib,
+                    open,
+                    close,
+                    directory,
+                    read,
+                    rm,
+                    write,
+                });
+            }
+        }
+        Err(last_load_error.unwrap())
     }
 }


### PR DESCRIPTION
Helps to fix #16
`libxenstore.so` implies a dependency on [`libxen-dev`](https://packages.ubuntu.com/kinetic/amd64/libxen-dev/filelist) package, which provides:

```shell
/usr/lib/x86_64-linux-gnu/libxenstore.a
/usr/lib/x86_64-linux-gnu/libxenstore.so
```
 However, it's just a symlink to `libxenstore.so.4`
```shell
lrwxrwxrwx 1 root root 16 févr.  6  2023 /usr/lib/x86_64-linux-gnu/libxenstore.so -> libxenstore.so.4
```

`libxenstore.so.4` is provided by [`libxenstore4`](https://packages.ubuntu.com/kinetic/amd64/libxenstore4/filelist) runtime
```
/usr/lib/x86_64-linux-gnu/libxenstore.so.4
/usr/lib/x86_64-linux-gnu/libxenstore.so.4.0
```

Therefore to remove the runtime dependency on `libxen-dev`, this PR proposes to load directly `libxenstore.so.4`.

We cannot use the [`libloading::library_filename`](https://docs.rs/libloading/latest/libloading/fn.library_filename.html) anymore, since it appends the `.so`suffix anyway, even if it's already present.

A Dockerfile to repro:
```Dockerfile
FROM ubuntu:22.04

RUN <<EOF
apt-get update
apt-get install -y git build-essential clang curl libxenstore4
EOF

RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
ENV PATH="/root/.cargo/bin:${PATH}"

RUN git clone https://github.com/Wenzel/xenstore -b libloading_xenstore4 /root/xenstore
WORKDIR /root/xenstore
RUN cargo build
# remove libxenstore.so
RUN find /usr/ -name libxenstore.so -exec rm {} \;
# run example
ENV RUST_LOG=info
RUN cargo run --example xenstore-cli -- list
# should error on xenstore open
# thread 'main' panicked at examples/xenstore-cli.rs:40:45:
# xenstore should open: Os { code: 2, kind: NotFound, message: "No such file or directory" }
# note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```