### PR TITLE
Remove enum derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ categories = ["api-bindings"]
 [dependencies]
 libloading = "0.8.0"
 log = "0.4.20"
-enum-primitive-derive = "0.2.2"
-num-traits = "0.2.16"
 xenstore-sys = "0.1.2"
 libc = "0.2.148"
 

--- a/examples/xenstore-cli.rs
+++ b/examples/xenstore-cli.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use xenstore_rs::{XBTransaction, Xs, XsOpenFlags};
+use xenstore_rs::{Xs, XsOpenFlags};
 
 /// Demo/test tool for xenstore Rust bindings
 #[derive(Parser)]
@@ -48,27 +48,22 @@ fn main() {
 }
 
 fn cmd_list(xs: &Xs, path: &String) {
-    let values = xs
-        .directory(XBTransaction::Null, &path)
-        .expect("path should be readable");
+    let values = xs.directory(None, &path).expect("path should be readable");
     for value in values {
         println!("{}", value);
     }
 }
 
 fn cmd_read(xs: &Xs, path: &String) {
-    let value = xs
-        .read(XBTransaction::Null, &path)
-        .expect("path should be readable");
+    let value = xs.read(None, &path).expect("path should be readable");
     println!("{}", value);
 }
 
 fn cmd_rm(xs: &Xs, path: &String) {
-    xs.rm(XBTransaction::Null, &path)
-        .expect("cannot rm xenstore path");
+    xs.rm(None, &path).expect("cannot rm xenstore path");
 }
 
 fn cmd_write(xs: &Xs, path: &String, data: &String) {
-    xs.write(XBTransaction::Null, &path, &data)
+    xs.write(None, &path, &data)
         .expect("cannot write to xenstore path");
 }


### PR DESCRIPTION
Solve #18 

This PRs removes the dependency on `enum-primitive-derive`, by updating the XBTransaction type to an `Option<u32>`:

```diff
-#[repr(u32)]
-#[derive(Primitive)]
-pub enum XBTransaction {
-    Null = xenstore_sys::XBT_NULL,
-}
+pub type XBTransaction = Option<u32>;
```

Since it's a public type, this causes an API change:

```rust
let values = xs.directory(XBTransaction::None, &path);
```