### PR TITLE
Static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ libloading = "0.8.0"
 log = "0.4.20"
 xenstore-sys = "0.1.2"
 libc = "0.2.148"
-tokio = { version = "1.0", features = ["sync", "net", "io-util", "rt"], optional = true }
+tokio = { version = "1.0", features = [
+    "sync",
+    "net",
+    "io-util",
+    "rt",
+], optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
@@ -25,3 +30,8 @@ clap = { version = "4.1.4", features = ["derive"] }
 [features]
 default = ["async_watch"]
 async_watch = ["futures", "tokio"]
+# static linking libxenstore
+static = ["xenstore-sys/static"]
+
+[patch.crates-io]
+xenstore-sys = { git = "https://github.com/Wenzel/xenstore-sys.git", branch = "static_linking_pkg_config" }

--- a/src/libxenstore.rs
+++ b/src/libxenstore.rs
@@ -2,16 +2,6 @@ use libloading::Error;
 use std::os::raw::{c_char, c_int, c_uint, c_ulong, c_void};
 use xenstore_sys::{xs_handle, xs_transaction_t};
 
-#[cfg(not(feature = "static"))]
-use {
-    libloading::os::unix::Symbol as RawSymbol,
-    libloading::{Library, Symbol},
-};
-
-#[cfg(not(feature = "static"))]
-const LIBXENSTORE_SONAME_LIST: [&str; 2] = ["3.0", "4"];
-#[cfg(not(feature = "static"))]
-const LIBXENSTORE_BASENAME: &str = "libxenstore.so";
 // xs_open
 type FnOpen = fn(flags: c_ulong) -> *mut xs_handle;
 // xs_close
@@ -52,192 +42,212 @@ type FnReadWatch = fn(h: *mut xs_handle, num: *mut c_uint) -> *mut *mut c_char;
 type FnUnwatch = fn(h: *mut xs_handle, path: *const c_char, token: *const c_char) -> bool;
 
 #[cfg(not(feature = "static"))]
-#[derive(Debug)]
-pub struct LibXenStore {
-    _lib: Library,
-    pub open: RawSymbol<FnOpen>,
-    pub close: RawSymbol<FnClose>,
-    pub directory: RawSymbol<FnDirectory>,
-    pub read: RawSymbol<FnRead>,
-    pub rm: RawSymbol<FnRm>,
-    pub write: RawSymbol<FnWrite>,
+mod dynamic {
+    use {
+        super::*,
+        libloading::os::unix::Symbol as RawSymbol,
+        libloading::{Library, Symbol},
+    };
 
-    pub watch: RawSymbol<FnWatch>,
-    pub fileno: RawSymbol<FnFileno>,
-    pub check_watch: RawSymbol<FnCheckWatch>,
-    pub read_watch: RawSymbol<FnReadWatch>,
-    pub unwatch: RawSymbol<FnUnwatch>,
+    const LIBXENSTORE_SONAME_LIST: [&str; 2] = ["3.0", "4"];
+    const LIBXENSTORE_BASENAME: &str = "libxenstore.so";
+
+    #[derive(Debug)]
+    pub struct LibXenStore {
+        _lib: Library,
+        pub open: RawSymbol<FnOpen>,
+        pub close: RawSymbol<FnClose>,
+        pub directory: RawSymbol<FnDirectory>,
+        pub read: RawSymbol<FnRead>,
+        pub rm: RawSymbol<FnRm>,
+        pub write: RawSymbol<FnWrite>,
+
+        pub watch: RawSymbol<FnWatch>,
+        pub fileno: RawSymbol<FnFileno>,
+        pub check_watch: RawSymbol<FnCheckWatch>,
+        pub read_watch: RawSymbol<FnReadWatch>,
+        pub unwatch: RawSymbol<FnUnwatch>,
+    }
+
+    impl LibXenStore {
+        /// Loads the libxenstore.so library dynamically, by trying multiple SONAMES
+        /// On failure it returns the last load error
+        pub unsafe fn new() -> Result<Self, Error> {
+            use log::info;
+            use std::ffi::OsString;
+
+            let mut last_load_error: Option<Error> = None;
+            for soname in LIBXENSTORE_SONAME_LIST {
+                let lib_filename = format!("{}.{}", LIBXENSTORE_BASENAME, soname);
+                info!("Loading {}", lib_filename);
+                let result = Library::new::<OsString>(lib_filename.clone().into());
+                if let Err(err) = result {
+                    info!("Failed to load {}", lib_filename);
+                    last_load_error = Some(err);
+                    continue;
+                } else {
+                    let lib = result.unwrap();
+                    // load symbols
+                    let open_sym: Symbol<FnOpen> = lib.get(b"xs_open\0")?;
+                    let open = open_sym.into_raw();
+
+                    let close_sym: Symbol<FnClose> = lib.get(b"xs_close\0")?;
+                    let close = close_sym.into_raw();
+
+                    let directory_sym: Symbol<FnDirectory> = lib.get(b"xs_directory\0")?;
+                    let directory = directory_sym.into_raw();
+
+                    let read_sym: Symbol<FnRead> = lib.get(b"xs_read\0")?;
+                    let read = read_sym.into_raw();
+
+                    let rm_sym: Symbol<FnRm> = lib.get(b"xs_rm\0")?;
+                    let rm = rm_sym.into_raw();
+
+                    let write_sym: Symbol<FnWrite> = lib.get(b"xs_write\0")?;
+                    let write = write_sym.into_raw();
+
+                    let watch_sym: Symbol<FnWatch> = lib.get(b"xs_watch\0")?;
+                    let watch = watch_sym.into_raw();
+
+                    let fileno_sym: Symbol<FnFileno> = lib.get(b"xs_fileno\0")?;
+                    let fileno = fileno_sym.into_raw();
+
+                    let check_watch_sym: Symbol<FnCheckWatch> = lib.get(b"xs_check_watch\0")?;
+                    let check_watch = check_watch_sym.into_raw();
+
+                    let read_watch_sym: Symbol<FnReadWatch> = lib.get(b"xs_read_watch\0")?;
+                    let read_watch = read_watch_sym.into_raw();
+
+                    let unwatch_sym: Symbol<FnUnwatch> = lib.get(b"xs_unwatch\0")?;
+                    let unwatch = unwatch_sym.into_raw();
+
+                    return Ok(LibXenStore {
+                        _lib: lib,
+                        open,
+                        close,
+                        directory,
+                        read,
+                        rm,
+                        write,
+                        watch,
+                        fileno,
+                        check_watch,
+                        read_watch,
+                        unwatch,
+                    });
+                }
+            }
+            Err(last_load_error.unwrap())
+        }
+    }
 }
 
 #[cfg(feature = "static")]
-#[derive(Debug)]
-pub struct LibXenStore {
-    pub open: FnOpen,
-    pub close: FnClose,
-    pub directory: FnDirectory,
-    pub read: FnRead,
-    pub rm: FnRm,
-    pub write: FnWrite,
+mod statik {
+    use super::*;
 
-    pub watch: FnWatch,
-    pub fileno: FnFileno,
-    pub check_watch: FnCheckWatch,
-    pub read_watch: FnReadWatch,
-    pub unwatch: FnUnwatch,
-}
+    #[derive(Debug)]
+    pub struct LibXenStore {
+        pub open: FnOpen,
+        pub close: FnClose,
+        pub directory: FnDirectory,
+        pub read: FnRead,
+        pub rm: FnRm,
+        pub write: FnWrite,
 
-impl LibXenStore {
-    /// Loads the libxenstore.so library dynamically, by trying multiple SONAMES
-    /// On failure it returns the last load error
-    #[cfg(not(feature = "static"))]
-    pub unsafe fn new() -> Result<Self, Error> {
-        use log::info;
-        use std::ffi::OsString;
+        pub watch: FnWatch,
+        pub fileno: FnFileno,
+        pub check_watch: FnCheckWatch,
+        pub read_watch: FnReadWatch,
+        pub unwatch: FnUnwatch,
+    }
 
-        let mut last_load_error: Option<Error> = None;
-        for soname in LIBXENSTORE_SONAME_LIST {
-            let lib_filename = format!("{}.{}", LIBXENSTORE_BASENAME, soname);
-            info!("Loading {}", lib_filename);
-            let result = Library::new::<OsString>(lib_filename.clone().into());
-            if let Err(err) = result {
-                info!("Failed to load {}", lib_filename);
-                last_load_error = Some(err);
-                continue;
-            } else {
-                let lib = result.unwrap();
-                // load symbols
-                let open_sym: Symbol<FnOpen> = lib.get(b"xs_open\0")?;
-                let open = open_sym.into_raw();
+    impl LibXenStore {
+        pub unsafe fn new() -> Result<Self, Error> {
+            use xenstore_sys::{
+                xs_check_watch, xs_close, xs_directory, xs_fileno, xs_open, xs_read, xs_read_watch,
+                xs_rm, xs_unwatch, xs_watch, xs_write,
+            };
 
-                let close_sym: Symbol<FnClose> = lib.get(b"xs_close\0")?;
-                let close = close_sym.into_raw();
-
-                let directory_sym: Symbol<FnDirectory> = lib.get(b"xs_directory\0")?;
-                let directory = directory_sym.into_raw();
-
-                let read_sym: Symbol<FnRead> = lib.get(b"xs_read\0")?;
-                let read = read_sym.into_raw();
-
-                let rm_sym: Symbol<FnRm> = lib.get(b"xs_rm\0")?;
-                let rm = rm_sym.into_raw();
-
-                let write_sym: Symbol<FnWrite> = lib.get(b"xs_write\0")?;
-                let write = write_sym.into_raw();
-
-                let watch_sym: Symbol<FnWatch> = lib.get(b"xs_watch\0")?;
-                let watch = watch_sym.into_raw();
-
-                let fileno_sym: Symbol<FnFileno> = lib.get(b"xs_fileno\0")?;
-                let fileno = fileno_sym.into_raw();
-
-                let check_watch_sym: Symbol<FnCheckWatch> = lib.get(b"xs_check_watch\0")?;
-                let check_watch = check_watch_sym.into_raw();
-
-                let read_watch_sym: Symbol<FnReadWatch> = lib.get(b"xs_read_watch\0")?;
-                let read_watch = read_watch_sym.into_raw();
-
-                let unwatch_sym: Symbol<FnUnwatch> = lib.get(b"xs_unwatch\0")?;
-                let unwatch = unwatch_sym.into_raw();
-
-                return Ok(LibXenStore {
-                    _lib: lib,
-                    open,
-                    close,
-                    directory,
-                    read,
-                    rm,
-                    write,
-                    watch,
-                    fileno,
-                    check_watch,
-                    read_watch,
-                    unwatch,
-                });
+            // write safe Rust wrappers to unsafe extern "C" functions
+            fn safe_open(flags: c_ulong) -> *mut xs_handle {
+                unsafe { xs_open(flags) }
             }
+
+            fn safe_close(xsh: *mut xs_handle) {
+                unsafe { xs_close(xsh) }
+            }
+
+            fn safe_directory(
+                h: *mut xs_handle,
+                t: xs_transaction_t,
+                path: *const c_char,
+                num: *mut c_uint,
+            ) -> *mut *mut c_char {
+                unsafe { xs_directory(h, t, path, num) }
+            }
+
+            fn safe_read(
+                h: *mut xs_handle,
+                t: xs_transaction_t,
+                path: *const c_char,
+                len: *mut c_uint,
+            ) -> *mut c_void {
+                unsafe { xs_read(h, t, path, len) }
+            }
+
+            fn safe_rm(h: *mut xs_handle, t: xs_transaction_t, path: *const c_char) -> bool {
+                unsafe { xs_rm(h, t, path) }
+            }
+
+            fn safe_write(
+                h: *mut xs_handle,
+                t: xs_transaction_t,
+                path: *const c_char,
+                data: *const c_void,
+                len: c_uint,
+            ) -> bool {
+                unsafe { xs_write(h, t, path, data, len) }
+            }
+
+            fn safe_watch(h: *mut xs_handle, path: *const c_char, token: *const c_char) -> bool {
+                unsafe { xs_watch(h, path, token) }
+            }
+
+            fn safe_fileno(h: *mut xs_handle) -> c_int {
+                unsafe { xs_fileno(h) }
+            }
+
+            fn safe_check_watch(h: *mut xs_handle) -> *mut *mut c_char {
+                unsafe { xs_check_watch(h) }
+            }
+
+            fn safe_read_watch(h: *mut xs_handle, num: *mut c_uint) -> *mut *mut c_char {
+                unsafe { xs_read_watch(h, num) }
+            }
+
+            fn safe_unwatch(h: *mut xs_handle, path: *const c_char, token: *const c_char) -> bool {
+                unsafe { xs_unwatch(h, path, token) }
+            }
+
+            Ok(LibXenStore {
+                open: safe_open,
+                close: safe_close,
+                directory: safe_directory,
+                read: safe_read,
+                rm: safe_rm,
+                write: safe_write,
+                watch: safe_watch,
+                fileno: safe_fileno,
+                check_watch: safe_check_watch,
+                read_watch: safe_read_watch,
+                unwatch: safe_unwatch,
+            })
         }
-        Err(last_load_error.unwrap())
-    }
-
-    #[cfg(feature = "static")]
-    pub unsafe fn new() -> Result<Self, Error> {
-        use xenstore_sys::{
-            xs_check_watch, xs_close, xs_directory, xs_fileno, xs_open, xs_read, xs_read_watch,
-            xs_rm, xs_unwatch, xs_watch, xs_write,
-        };
-
-        // write safe Rust wrappers to unsafe extern "C" functions
-        fn safe_open(flags: c_ulong) -> *mut xs_handle {
-            unsafe { xs_open(flags) }
-        }
-
-        fn safe_close(xsh: *mut xs_handle) {
-            unsafe { xs_close(xsh) }
-        }
-
-        fn safe_directory(
-            h: *mut xs_handle,
-            t: xs_transaction_t,
-            path: *const c_char,
-            num: *mut c_uint,
-        ) -> *mut *mut c_char {
-            unsafe { xs_directory(h, t, path, num) }
-        }
-
-        fn safe_read(
-            h: *mut xs_handle,
-            t: xs_transaction_t,
-            path: *const c_char,
-            len: *mut c_uint,
-        ) -> *mut c_void {
-            unsafe { xs_read(h, t, path, len) }
-        }
-
-        fn safe_rm(h: *mut xs_handle, t: xs_transaction_t, path: *const c_char) -> bool {
-            unsafe { xs_rm(h, t, path) }
-        }
-
-        fn safe_write(
-            h: *mut xs_handle,
-            t: xs_transaction_t,
-            path: *const c_char,
-            data: *const c_void,
-            len: c_uint,
-        ) -> bool {
-            unsafe { xs_write(h, t, path, data, len) }
-        }
-
-        fn safe_watch(h: *mut xs_handle, path: *const c_char, token: *const c_char) -> bool {
-            unsafe { xs_watch(h, path, token) }
-        }
-
-        fn safe_fileno(h: *mut xs_handle) -> c_int {
-            unsafe { xs_fileno(h) }
-        }
-
-        fn safe_check_watch(h: *mut xs_handle) -> *mut *mut c_char {
-            unsafe { xs_check_watch(h) }
-        }
-
-        fn safe_read_watch(h: *mut xs_handle, num: *mut c_uint) -> *mut *mut c_char {
-            unsafe { xs_read_watch(h, num) }
-        }
-
-        fn safe_unwatch(h: *mut xs_handle, path: *const c_char, token: *const c_char) -> bool {
-            unsafe { xs_unwatch(h, path, token) }
-        }
-
-        Ok(LibXenStore {
-            open: safe_open,
-            close: safe_close,
-            directory: safe_directory,
-            read: safe_read,
-            rm: safe_rm,
-            write: safe_write,
-            watch: safe_watch,
-            fileno: safe_fileno,
-            check_watch: safe_check_watch,
-            read_watch: safe_read_watch,
-            unwatch: safe_unwatch,
-        })
     }
 }
+
+#[cfg(not(feature = "static"))]
+pub use dynamic::LibXenStore;
+#[cfg(feature = "static")]
+pub use statik::LibXenStore;


### PR DESCRIPTION
Add static linking to xenstore with the `static` feature.

Rely on https://github.com/Wenzel/xenstore-sys/pull/11

Without static linking, ltrace logs a call to `dlopen`:
```shell
vagrant@ubuntu2204:/vagrant/rust/xenstore$ CARGO_TARGET_DIR=/home/vagrant/xenstore  cargo build --example xenstore-cli
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
warning: the following packages contain code that will be rejected by a future version of Rust: cexpr v0.3.6, nom v4.2.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
vagrant@ubuntu2204:/vagrant/rust/xenstore$ ltrace -f -x 'dlopen' /home/vagrant/xenstore/debug/examples/xenstore-cli list /
[pid 3724] dlopen@libc.so.6("libxenstore.so.3.0", 1)                                                                 = 0
[pid 3724] dlopen@libc.so.6("libxenstore.so.4", 1)                                                                   = 0x562ebf97ff90
thread 'main' panicked at examples/xenstore-cli.rs:51:45:
xenstore should open: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[pid 3724] _Unwind_Resume(0x562ebf986c10, 0, 0, 0x562ebda2bae9 <unfinished ...>
[pid 3724] _Unwind_Resume(0x562ebf986c10, 0x562ebf97f010, 0x562bdd73af96, 0 <unfinished ...>
[pid 3724] _Unwind_Resume(0x562ebf986c10, 0x562ebf97f010, 0x562bdd739216, 0 <no return ...>
[pid 3724] +++ exited (status 101) +++
```

With static linking, `dlopen` call is gone (and ltrace filtering capabilities seems a bit broken also, but that's another topic)
```shell
vagrant@ubuntu2204:/vagrant/rust/xenstore$ CARGO_TARGET_DIR=/home/vagrant/xenstore  cargo build --features static --example xenstore-cli 
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
warning: the following packages contain code that will be rejected by a future version of Rust: cexpr v0.3.6, nom v4.2.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
vagrant@ubuntu2204:/vagrant/rust/xenstore$ ltrace -f -x 'dlopen' /home/vagrant/xenstore/debug/examples/xenstore-cli list /
[pid 4859] __snprintf_chk(0x559be792d0e0, 4096, 1, 4096)                                                             = 25
[pid 4859] pthread_mutex_lock(0x559be792d0a0, 0, 88, 0x559be8865f20)                                                 = 0
[pid 4859] pthread_mutex_unlock(0x559be792d0a0, 0, 0, 0)                                                             = 0
[pid 4859] stat(0x559be792d0e0, 0x7ffd73498640, 0, 0)                                                                = 0
[pid 4859] socket(1, 1, 0)                                                                                           = 3
[pid 4859] __memcpy_chk(0x7ffd734985d2, 0x559be792d0e0, 26, 108)                                                     = 0x7ffd734985d2
[pid 4859] connect(3, 0x7ffd734985d0, 110, 108)                                                                      = 0xffffffff
[pid 4859] pthread_mutex_lock(0x559be792d0a0, 0x7ffd734985d0, -336, 0x7f9fe6df8157)                                  = 0
[pid 4859] pthread_mutex_unlock(0x559be792d0a0, 0, 0x559be792d080, 0)                                                = 0
[pid 4859] access("/dev/xen/xenbus", 0)                                                                              = 0
[pid 4859] pthread_mutex_lock(0x559be792d0a0, 0, 88, 0x559be8865f80)                                                 = 0
[pid 4859] pthread_mutex_unlock(0x559be792d0a0, 0, 0, 0)                                                             = 0
[pid 4859] stat(0x559be78b0f61, 0x7ffd73498640, 0, 0)                                                                = 0
[pid 4859] open("/dev/xen/xenbus", 2, 016322303100)                                                                  = -1
[pid 4859] pthread_mutex_lock(0x559be792d0a0, 0x559be78b0f61, 0, 0x7f9fe6df772b)                                     = 0
[pid 4859] pthread_mutex_unlock(0x559be792d0a0, 0, 0x559be792d080, 0)                                                = 0
thread 'main' panicked at examples/xenstore-cli.rs:51:45:
xenstore should open: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[pid 4859] _Unwind_Resume(0x559be886cc10, 0, 0, 0x559be7886f19 <unfinished ...>
[pid 4859] _Unwind_Resume(0x559be886cc10, 0x559be8865010, 0x559eb1383dec, 0 <unfinished ...>
[pid 4859] _Unwind_Resume(0x559be886cc10, 0x559be8865010, 0x559eb13843fc, 0 <no return ...>
[pid 4859] +++ exited (status 101) +++
```

The implementation can be refactored, the `cfg(feature)` is used in too many places. 