### PR TITLE
Fix deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ features = ["v4"]
 optional = true
 
 [dependencies.libc] # needed to O_NONBLOCK
-version = "*"
+version = "0.2.168"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.1.2"
 optional = true
 
 [dependencies.futures]
-version = "0.3"
+version = "0.3.31"
 default-features = false
 optional = true
 


### PR DESCRIPTION
Small dependencies fixes for crates.io publication

- wildcard (`*`) dependency constraints are not allowed on crates.io
- package `futures-util v0.3.29` in Cargo.lock is yanked in registry `crates-io`