### PR TITLE
Introduce watch with depth

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,3 +101,15 @@ pub trait LocalAsyncWatch {
         path: &str,
     ) -> io::Result<impl futures::Stream<Item = Box<str>> + Unpin + 'static>;
 }
+
+/// Xenstore watch with depth capability.
+#[cfg(feature = "async")]
+#[trait_variant::make(AsyncWatchDepth: Send)]
+pub trait LocalAsyncWatchDepth {
+    /// Create a [`futures::Stream`] yielding paths of updated nodes/subnodes.
+    async fn watch_depth(
+        &self,
+        path: &str,
+        depth: Option<u32>,
+    ) -> io::Result<impl futures::Stream<Item = Box<str>> + Unpin + 'static>;
+}


### PR DESCRIPTION
xenstore protocol has a optional 3rd parameter for specifying the depth of watch.
It can be useful for not capturing events of sub-entries (which we may not want depending on context).
https://github.com/xen-project/xen/blob/master/docs/misc/xenstore.txt#L193

TODO: 
- test the implementation
- do we want to merge this into AsyncXsWatch trait ?
    - the unfortunate thing is that Windows xenstore driver doesn't support depth yet
      https://github.com/xcp-ng/win-xeniface/blob/master/include/xeniface_ioctls.h#L120-L134