### PR TITLE
Generic async and smol runtime support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,27 @@ optional = true
 version = "0.2.168"
 optional = true
 
+# Smol/async-std implementation dependencies
+[dependencies.async-fs]
+version = "2.1.2"
+optional = true
+
+[dependencies.async-io]
+version = "2.4.0"
+optional = true
+
+[dependencies.async-net]
+version = "2.0.0"
+optional = true
+
+[dependencies.async-executor]
+version = "1.13.1"
+optional = true
+
 [dev-dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
 colog = "1.3.0"
+smol = "2.0.2"
 
 [features]
 default = ["unix"]
@@ -70,3 +88,10 @@ unix = []
 async = ["futures", "trait-variant"]
 async-generic = ["log", "async", "flume", "thiserror", "uuid"]
 async-tokio = ["async-generic", "tokio", "tokio-util", "libc"]
+async-smol = [
+    "async-generic",
+    "async-fs",
+    "async-io",
+    "async-net",
+    "async-executor",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,26 +24,36 @@ optional = true
 
 [dependencies.futures]
 version = "0.3.31"
-default-features = false
+features = ["write-all-vectored"]
 optional = true
 
-# Tokio implementation dependencies
 [dependencies.log] # Logging
 version = "0.4"
 optional = true
 
-[dependencies.anyhow] # Error handling
-version = "1.0"
+[dependencies.thiserror] # Error handling
+version = "2.0.18"
 optional = true
 
-[dependencies.tokio]
-version = "1.0"
-features = ["sync", "net", "io-util", "rt", "fs", "macros"]
+[dependencies.flume] # Used for mpsc channels as futures::mpsc needs &mut
+version = "0.11.1"
+features = ["async"]
 optional = true
 
 [dependencies.uuid] # Used for xenstore token generation/management
 version = "1.11"
 features = ["v4"]
+optional = true
+
+# Tokio implementation dependencies
+[dependencies.tokio]
+version = "1.0"
+features = ["net", "io-util", "rt", "macros"]
+optional = true
+
+[dependencies.tokio-util] # Compatibility with futures's AsyncRead/Write
+version = "0.7.13"
+features = ["compat"]
 optional = true
 
 [dependencies.libc] # needed to O_NONBLOCK
@@ -58,4 +68,5 @@ colog = "1.3.0"
 default = ["unix"]
 unix = []
 async = ["futures", "trait-variant"]
-async-tokio = ["log", "async", "tokio", "anyhow", "uuid", "libc"]
+async-generic = ["log", "async", "flume", "thiserror", "uuid"]
+async-tokio = ["async-generic", "tokio", "tokio-util", "libc"]

--- a/examples/xenstore-cli-smol.rs
+++ b/examples/xenstore-cli-smol.rs
@@ -1,0 +1,127 @@
+use clap::{Parser, Subcommand};
+use futures::StreamExt;
+use smol::Executor;
+use xenstore_rs::{smol::XsSmol, AsyncWatch, AsyncXs, AsyncXsPerm};
+
+/// Demo/test tool for xenstore Rust bindings
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// List Xenstore keys in path
+    List {
+        #[arg()]
+        path: String,
+    },
+    /// Read value of Xenstore path
+    Read {
+        #[arg()]
+        path: String,
+    },
+    /// Remove value of Xenstore path
+    Rm {
+        #[arg()]
+        path: String,
+    },
+    /// Write value to Xenstore path
+    Write {
+        #[arg()]
+        path: String,
+        #[arg()]
+        data: String,
+    },
+    /// Watch on path on Xenstore.
+    Watch {
+        #[arg()]
+        path: String,
+    },
+    /// Get node permissions.
+    GetPerms {
+        #[arg()]
+        path: String,
+    },
+    /// Set node permissions
+    SetPerms {
+        #[arg()]
+        path: String,
+        #[arg()]
+        perms: Vec<String>,
+    },
+}
+
+fn main() {
+    colog::init();
+    let cli = Cli::parse();
+
+    let executor = Executor::new();
+
+    smol::block_on(executor.run(async {
+        let mut xs = XsSmol::new(&executor).await.expect("xenstore should open");
+
+        match cli.command {
+            Command::List { path } => cmd_list(&mut xs, &path).await,
+            Command::Read { path } => cmd_read(&mut xs, &path).await,
+            Command::Rm { path } => cmd_rm(&mut xs, &path).await,
+            Command::Write { path, data } => cmd_write(&mut xs, &path, &data).await,
+            Command::Watch { path } => cmd_watch(&mut xs, &path).await,
+            Command::GetPerms { path } => cmd_get_perms(&mut xs, &path).await,
+            Command::SetPerms { path, perms } => cmd_set_perms(&mut xs, &path, &perms).await,
+        }
+    }));
+
+    drop(executor);
+}
+
+async fn cmd_list(xs: &mut impl AsyncXs, path: &String) {
+    let values = xs.directory(&path).await.expect("path should be readable");
+    for value in values {
+        println!("{}", value);
+    }
+}
+
+async fn cmd_read(xs: &mut impl AsyncXs, path: &String) {
+    let value = xs.read(&path).await.expect("path should be readable");
+    println!("{}", value);
+}
+
+async fn cmd_rm(xs: &mut impl AsyncXs, path: &String) {
+    xs.rm(&path).await.expect("cannot rm xenstore path");
+}
+
+async fn cmd_write(xs: &mut impl AsyncXs, path: &String, data: &String) {
+    xs.write(&path, &data)
+        .await
+        .expect("cannot write to xenstore path");
+}
+
+async fn cmd_watch<XS: AsyncXs + AsyncWatch>(xs: &mut XS, path: &String) {
+    let mut stream = xs.watch(&path).await.expect("path should be watchable");
+
+    while let Some(entry) = stream.next().await {
+        println!("{entry}: {:?}", xs.read(&entry).await);
+    }
+}
+
+async fn cmd_get_perms(xs: &mut impl AsyncXsPerm, path: &String) {
+    let perms = xs.get_perms(path).await.expect("path should be readable");
+
+    for perm in perms {
+        println!("{perm}");
+    }
+}
+
+async fn cmd_set_perms(xs: &mut impl AsyncXsPerm, path: &String, perms: &[String]) {
+    let perms = perms
+        .iter()
+        .map(|s| s.parse())
+        .collect::<Result<Vec<_>, _>>()
+        .expect("Unable to parse permissions");
+
+    xs.set_perms(path, &perms)
+        .await
+        .expect("Unable to set permissions");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub mod unix;
 #[cfg(feature = "async-tokio")]
 pub mod tokio;
 
+#[cfg(feature = "async-generic")]
+pub mod xs_async;
+
 use std::io;
 
 #[derive(Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,10 @@ pub mod unix;
 #[cfg(feature = "async-tokio")]
 pub mod tokio;
 
+#[cfg(not(target_os = "windows"))]
+#[cfg(feature = "async-smol")]
+pub mod smol;
+
 #[cfg(feature = "async-generic")]
 pub mod xs_async;
 

--- a/src/smol/device.rs
+++ b/src/smol/device.rs
@@ -1,0 +1,66 @@
+//! xenbus device with AsyncWrite/AsyncRead.
+//!
+use std::{
+    fs::File,
+    io::{self, Write},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use async_io::Async;
+use futures::{AsyncRead, AsyncWrite};
+
+use crate::wire::XENBUS_DEVICE_PATH;
+
+#[derive(Clone)]
+pub struct XsDevice(Arc<Async<File>>);
+
+impl XsDevice {
+    pub async fn new() -> io::Result<Self> {
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .open(XENBUS_DEVICE_PATH)?;
+
+        Ok(Self(Arc::new(Async::new(file)?)))
+    }
+}
+
+impl AsyncRead for XsDevice {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let pinned = std::pin::pin!(self.0.as_ref());
+        pinned.poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for XsDevice {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        // There is a bug in xenbus device that makes poll never yield EPOLLOUT,
+        // we need to ignore it and assume that we can always write (xenbus will
+        // buffer in that case).
+        loop {
+            match self.0.get_ref().write(buf) {
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                result => return Poll::Ready(result),
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(self.0.get_ref().flush())
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let pinned = std::pin::pin!(self.0.as_ref());
+        pinned.poll_close(cx)
+    }
+}

--- a/src/smol/mod.rs
+++ b/src/smol/mod.rs
@@ -1,0 +1,150 @@
+//! smol/async-std async implementation.
+//!
+//! Alike Unix implementation, uses either xenstored socket or xenbus/xenstore device.
+//!
+//! This implementation uses a underlying task to multiplex the concurrent
+//! accesses and manage watchers. If this underlying task dies (e.g dead xenstore socket),
+//! all future operations will fail with [io::ErrorKind::BrokenPipe] and all watchers
+//! will yield [None].
+
+// TODO: Use at some point Spawn trait.
+// See https://github.com/smol-rs/async-executor/issues/25
+
+mod device;
+
+use std::{env, io, marker::PhantomData};
+
+use futures::{AsyncRead, AsyncWrite, Stream};
+use log::{debug, error};
+
+use crate::{
+    wire::XsMessage,
+    xs_async::{XsAsyncImpl, XsAsyncState},
+    AsyncWatch, AsyncXs, AsyncXsPerm, XsPermission,
+};
+
+use async_executor::Executor;
+use async_net::unix::UnixStream;
+
+/// Smol Xenstore implementation.
+///
+/// It can be cloned and used concurrently by multiple tasks.
+#[derive(Clone, Debug)]
+pub struct XsSmol<'a>(XsAsyncImpl, PhantomData<Executor<'a>>);
+
+impl<'a> XsSmol<'a> {
+    /// Try to open Xenstore interface.
+    /// Attempt in order :
+    ///  - `/run/xenstored/socket` (unix domain socket)
+    ///  - [crate::wire::XENBUS_DEVICE_PATH] (xenstore device)
+    pub async fn new(executor: &Executor<'a>) -> io::Result<Self> {
+        let xsd_path =
+            env::var("XENSTORED_PATH").unwrap_or_else(|_| "/run/xenstored/socket".to_string());
+
+        // Use xenstored socket first
+        if let Ok(stream) = UnixStream::connect(xsd_path).await {
+            return Ok(Self(
+                run_xenstore_task(executor, stream.clone(), stream)?,
+                PhantomData,
+            ));
+        }
+
+        let device = device::XsDevice::new().await?;
+        Ok(Self(
+            run_xenstore_task(executor, device.clone(), device)?,
+            PhantomData,
+        ))
+    }
+}
+
+impl AsyncXs for XsSmol<'_> {
+    async fn directory(&self, path: &str) -> io::Result<Vec<Box<str>>> {
+        self.0.directory(path).await
+    }
+
+    async fn read(&self, path: &str) -> io::Result<Box<str>> {
+        self.0.read(path).await
+    }
+
+    async fn write(&self, path: &str, data: &str) -> io::Result<()> {
+        self.0.write(path, data).await
+    }
+
+    async fn rm(&self, path: &str) -> io::Result<()> {
+        self.0.rm(path).await
+    }
+}
+
+impl AsyncWatch for XsSmol<'_> {
+    async fn watch(
+        &self,
+        path: &str,
+    ) -> io::Result<impl Stream<Item = Box<str>> + Unpin + 'static> {
+        self.0.watch(path).await
+    }
+}
+
+impl AsyncXsPerm for XsSmol<'_> {
+    async fn get_perms(&self, path: &str) -> io::Result<Vec<XsPermission>> {
+        self.0.get_perms(path).await
+    }
+
+    async fn set_perms(&self, path: &str, perms: &[XsPermission]) -> io::Result<()> {
+        self.0.set_perms(path, perms).await
+    }
+}
+
+pub fn run_xenstore_task<R, W>(
+    executor: &Executor<'_>,
+    mut xs_read: R,
+    mut xs_write: W,
+) -> io::Result<XsAsyncImpl>
+where
+    R: AsyncRead + Send + Unpin + 'static,
+    W: AsyncWrite + Send + Unpin + 'static,
+{
+    // Xenstore response channel
+    let (response_tx, xs_receiver) = flume::bounded(4);
+
+    // Xenstore request channel
+    let (xs_sender, request_rx) = flume::bounded(4);
+
+    // Xenstore Rust channel
+    let (xs_async_tx, xs_async_rx) = flume::unbounded();
+
+    // Message receiver task
+    executor
+        .spawn(async move {
+            while let Ok(message) = XsMessage::read_message_async(&mut xs_read).await {
+                debug!("< {message:?}");
+
+                if response_tx.send_async(message).await.is_err() {
+                    break;
+                }
+            }
+
+            error!("Read message failure");
+        })
+        .detach();
+
+    // Message sender task
+    executor
+        .spawn(async move {
+            while let Ok(message) = request_rx.recv_async().await {
+                debug!("> {message:?}");
+
+                if let Err(e) = XsMessage::write_message_async(&message, &mut xs_write).await {
+                    error!("Write message failure {e}");
+                    break;
+                }
+            }
+        })
+        .detach();
+
+    let state = XsAsyncState::default();
+    executor
+        .spawn(state.run(xs_async_rx, xs_receiver, xs_sender))
+        .detach();
+
+    XsAsyncImpl::new(xs_async_tx)
+}

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -8,27 +8,20 @@
 //! will yield [None].
 
 mod device;
-mod interface;
-mod wire_async;
 
-use std::{
-    env,
-    io::{self, ErrorKind},
-    pin::Pin,
-    str::FromStr,
-    task::{Context, Poll},
-};
+use std::{env, io};
 
 use futures::Stream;
+use log::{debug, error};
 use tokio::{
+    io::{AsyncRead, AsyncWrite},
     net::UnixStream,
-    sync::{mpsc, oneshot},
 };
-
-use interface::{launch_xenstore_task, XsTokioMessage, XsTokioRequest, XsWatchToken};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::{
-    wire::{XsMessage, XsMessageType},
+    wire::XsMessage,
+    xs_async::{XsAsyncImpl, XsAsyncState},
     AsyncWatch, AsyncXs, AsyncXsPerm, XsPermission,
 };
 
@@ -36,7 +29,7 @@ use crate::{
 ///
 /// It can be cloned and used concurrently by multiple tasks.
 #[derive(Clone, Debug)]
-pub struct XsTokio(mpsc::UnboundedSender<XsTokioMessage>);
+pub struct XsTokio(XsAsyncImpl);
 
 impl XsTokio {
     /// Try to open Xenstore interface.
@@ -49,172 +42,94 @@ impl XsTokio {
 
         // Use xenstored socket first
         if let Ok(stream) = UnixStream::connect(xsd_path).await {
-            return Ok(Self(launch_xenstore_task(stream)));
+            return Ok(Self(launch_xenstore_task(stream)?));
         }
 
-        Ok(Self(launch_xenstore_task(device::XsDevice::new().await?)))
-    }
-
-    async fn transmit_request(&self, request: XsMessage) -> io::Result<XsMessage> {
-        let (response_sender, response_receiver) = oneshot::channel();
-        let req_msg_type = request.msg_type;
-
-        self.0
-            .send(XsTokioMessage::Request(XsTokioRequest {
-                request,
-                response_sender,
-            }))
-            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))?;
-
-        let response = response_receiver
-            .await
-            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))?;
-
-        match response.msg_type {
-            // Response type must match request.
-            msg_type if msg_type == req_msg_type => Ok(response),
-            XsMessageType::Error => Err(response.parse_error()),
-            msg_type => Err(io::Error::new(
-                ErrorKind::InvalidData,
-                format!("Got unrelated response ({msg_type:?})"),
-            )),
-        }
+        Ok(Self(launch_xenstore_task(device::XsDevice::new().await?)?))
     }
 }
 
 impl AsyncXs for XsTokio {
     async fn directory(&self, path: &str) -> io::Result<Vec<Box<str>>> {
-        let response = self
-            .transmit_request(XsMessage::from_string(XsMessageType::Directory, 0, path))
-            .await?;
-
-        Ok(response
-            .parse_payload_list()
-            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
-            // convert &str to Box<str>
-            .iter()
-            .map(|s| s.to_string().into_boxed_str())
-            .collect())
+        self.0.directory(path).await
     }
 
     async fn read(&self, path: &str) -> io::Result<Box<str>> {
-        let response = self
-            .transmit_request(XsMessage::from_string(XsMessageType::Read, 0, path))
-            .await?;
-
-        Ok(response
-            .parse_payload_str()
-            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
-            .unwrap_or_default()
-            // convert &str to Box<str>
-            .to_string()
-            .into_boxed_str())
+        self.0.read(path).await
     }
 
     async fn write(&self, path: &str, data: &str) -> io::Result<()> {
-        self.transmit_request(XsMessage::from_string_slice(
-            XsMessageType::Write,
-            0,
-            &[path, data],
-            false,
-        ))
-        .await?;
-
-        Ok(())
+        self.0.write(path, data).await
     }
 
     async fn rm(&self, path: &str) -> io::Result<()> {
-        self.transmit_request(XsMessage::from_string(XsMessageType::Rm, 0, path))
-            .await?;
+        self.0.rm(path).await
+    }
+}
 
-        Ok(())
+impl AsyncWatch for XsTokio {
+    async fn watch(
+        &self,
+        path: &str,
+    ) -> io::Result<impl Stream<Item = Box<str>> + Unpin + 'static> {
+        self.0.watch(path).await
     }
 }
 
 impl AsyncXsPerm for XsTokio {
     async fn get_perms(&self, path: &str) -> io::Result<Vec<XsPermission>> {
-        let response = self
-            .transmit_request(XsMessage::from_string(XsMessageType::GetPerms, 0, path))
-            .await?;
-
-        let payloads = response
-            .parse_payload_list()
-            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
-
-        payloads
-            .iter()
-            .map(|s| XsPermission::from_str(s).map_err(io::Error::other))
-            .collect()
+        self.0.get_perms(path).await
     }
 
     async fn set_perms(&self, path: &str, perms: &[XsPermission]) -> io::Result<()> {
-        // Build a parameter list for <path>|<perm-as-string>|+?
-        let perms_strings: Vec<String> = perms.iter().map(ToString::to_string).collect();
-
-        let mut perms_str: Vec<&str> = Vec::new();
-        perms_str.reserve_exact(1 + perms.len());
-
-        perms_str.push(path);
-        perms_strings.iter().for_each(|s| perms_str.push(s));
-
-        self.transmit_request(XsMessage::from_string_slice(
-            XsMessageType::SetPerms,
-            0,
-            &perms_str,
-            true,
-        ))
-        .await?;
-
-        Ok(())
+        self.0.set_perms(path, perms).await
     }
 }
 
-/// Tokio watch object.
-pub struct XsTokioWatch {
-    event_receiver: mpsc::Receiver<Box<str>>,
-    tokio_channel: mpsc::UnboundedSender<XsTokioMessage>,
-    token: XsWatchToken,
-}
+pub fn launch_xenstore_task<S>(xs_stream: S) -> io::Result<XsAsyncImpl>
+where
+    S: AsyncRead + AsyncWrite + Send + 'static,
+{
+    let (rx, tx) = tokio::io::split(xs_stream);
 
-impl Stream for XsTokioWatch {
-    type Item = Box<str>;
+    // Xenstore response channel
+    let (response_tx, xs_receiver) = flume::bounded(4);
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.event_receiver.poll_recv(cx)
-    }
-}
+    // Xenstore request channel
+    let (xs_sender, request_rx) = flume::bounded(4);
 
-impl Drop for XsTokioWatch {
-    fn drop(&mut self) {
-        // Try to unsubscribe upstream (to not leak the watch token/state).
-        // If it fails, it means that the upper backend has died.
-        self.tokio_channel
-            .send(XsTokioMessage::WatchUnsubscribe(self.token))
-            .ok();
-    }
-}
+    // Xenstore Rust channel
+    let (xs_async_tx, xs_async_rx) = flume::unbounded();
 
-impl AsyncWatch for XsTokio {
-    async fn watch(&self, path: &str) -> io::Result<impl Stream<Item = Box<str>> + 'static> {
-        let (event_sender, event_receiver) = mpsc::channel(8);
-        let (result_channel, result_receiver) = oneshot::channel();
+    // Message receiver task
+    tokio::spawn(async move {
+        let mut rx = rx.compat();
+        while let Ok(message) = XsMessage::read_message_async(&mut rx).await {
+            debug!("< {message:?}");
 
-        self.0
-            .send(XsTokioMessage::WatchSubscribe {
-                path: path.to_string().into_boxed_str(),
-                event_sender,
-                result_channel,
-            })
-            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))?;
+            if response_tx.send_async(message).await.is_err() {
+                break;
+            }
+        }
 
-        let token = result_receiver
-            .await
-            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))??;
+        error!("Read message failure");
+    });
 
-        Ok(XsTokioWatch {
-            event_receiver,
-            token,
-            tokio_channel: self.0.clone(),
-        })
-    }
+    // Message sender task
+    tokio::spawn(async move {
+        let mut tx = tx.compat_write();
+        while let Ok(message) = request_rx.recv_async().await {
+            debug!("> {message:?}");
+
+            if let Err(e) = XsMessage::write_message_async(&message, &mut tx).await {
+                error!("Write message failure {e}");
+                break;
+            }
+        }
+    });
+
+    let state = XsAsyncState::default();
+    tokio::spawn(state.run(xs_async_rx, xs_receiver, xs_sender));
+
+    XsAsyncImpl::new(xs_async_tx)
 }

--- a/src/xs_async/interface.rs
+++ b/src/xs_async/interface.rs
@@ -1,11 +1,11 @@
 use std::{cell::Cell, collections::HashMap};
 
-use anyhow::{anyhow, bail};
-use log::{debug, error, info, warn};
-use tokio::{
-    io::{self, AsyncRead, AsyncWrite, Error, ErrorKind},
-    sync::{mpsc, oneshot},
+use futures::{
+    channel::oneshot,
+    io::{self, Error, ErrorKind},
 };
+use log::{debug, info, warn};
+use thiserror::Error;
 use uuid::Uuid;
 
 use crate::wire::{XsMessage, XsMessageType};
@@ -13,25 +13,55 @@ use crate::wire::{XsMessage, XsMessageType};
 /// Maximum number of pending requests.
 const MAX_REQUEST_COUNT: usize = 32;
 
+#[derive(Error, Debug)]
+pub enum XsAsyncError {
+    #[error("no available slot")]
+    NoSlot,
+    #[error("unwatch without watch")]
+    UnwatchNoWatch,
+    #[error("channel error")]
+    BrokenChannel(#[source] flume::SendError<XsMessage>),
+    #[error("unwatch failed")]
+    UnwatchFailure,
+    #[error("received invalid response")]
+    InvalidResponse { expected: XsMessageType },
+    #[error("received invalid request id")]
+    InvalidRequestId,
+    #[error("no related request to this req_id")]
+    UnknownRequestId,
+    #[error("got non-uuid token")]
+    NonUuidToken(#[source] uuid::Error),
+    #[error("got non-utf8 payload")]
+    NonUtf8Payload(#[source] std::str::Utf8Error),
+    #[error("got invalid payload")]
+    InvalidPayload,
+}
+
+impl From<flume::SendError<XsMessage>> for XsAsyncError {
+    fn from(value: flume::SendError<XsMessage>) -> Self {
+        Self::BrokenChannel(value)
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct XsWatchToken(Uuid);
 
-pub struct XsTokioRequest {
+pub struct XsAsyncRequest {
     pub request: XsMessage,
     pub response_sender: oneshot::Sender<XsMessage>,
 }
 
-pub enum XsTokioMessage {
-    Request(XsTokioRequest),
+pub enum XsAsyncMessage {
+    Request(XsAsyncRequest),
     WatchSubscribe {
         path: Box<str>,
-        event_sender: mpsc::Sender<Box<str>>,
+        event_sender: flume::Sender<Box<str>>,
         result_channel: oneshot::Sender<io::Result<XsWatchToken>>,
     },
     WatchUnsubscribe(XsWatchToken),
 }
 
-enum XsTokioTask {
+enum XsAsyncTask {
     Request(oneshot::Sender<XsMessage>),
     WatchSubscribe {
         subscriber_info: WatchSubscriberInfo,
@@ -42,19 +72,16 @@ enum XsTokioTask {
 }
 
 struct WatchSubscriberInfo {
-    channel: mpsc::Sender<Box<str>>,
+    channel: flume::Sender<Box<str>>,
     // We need to store the watch patch as it is required by UNWATCH.
     path: Box<str>,
 }
 
-struct XsTokioState {
-    pending_tasks: [Cell<Option<XsTokioTask>>; MAX_REQUEST_COUNT],
+#[derive(Default)]
+pub struct XsAsyncState {
+    pending_tasks: [Cell<Option<XsAsyncTask>>; MAX_REQUEST_COUNT],
     watch_subscribers: HashMap<Uuid, WatchSubscriberInfo>,
     task_count: usize,
-
-    request_channel: mpsc::Sender<XsMessage>,
-    response_channel: mpsc::Receiver<XsMessage>,
-    message_receiver: mpsc::UnboundedReceiver<XsTokioMessage>,
 }
 
 fn find_suitable_token<V>(watch_subscribers: &HashMap<Uuid, V>) -> XsWatchToken {
@@ -68,8 +95,12 @@ fn find_suitable_token<V>(watch_subscribers: &HashMap<Uuid, V>) -> XsWatchToken 
     }
 }
 
-impl XsTokioState {
-    async fn process_message(&mut self, message: XsTokioMessage) -> anyhow::Result<()> {
+impl XsAsyncState {
+    async fn process_message(
+        &mut self,
+        message: XsAsyncMessage,
+        xs_sender: &flume::Sender<XsMessage>,
+    ) -> Result<(), XsAsyncError> {
         // Find a available task slot.
         let Some((req_id, slot)) = self
             .pending_tasks
@@ -78,21 +109,21 @@ impl XsTokioState {
             .enumerate()
             .find(|(_, slot)| slot.is_none())
         else {
-            bail!("No available slot");
+            return Err(XsAsyncError::NoSlot);
         };
 
         match message {
-            XsTokioMessage::Request(XsTokioRequest {
+            XsAsyncMessage::Request(XsAsyncRequest {
                 mut request,
                 response_sender,
             }) => {
                 request.request_id = req_id as u32;
 
-                self.request_channel.send(request).await?;
-                *slot = Some(XsTokioTask::Request(response_sender));
+                xs_sender.send_async(request).await?;
+                *slot = Some(XsAsyncTask::Request(response_sender));
                 self.task_count += 1;
             }
-            XsTokioMessage::WatchSubscribe {
+            XsAsyncMessage::WatchSubscribe {
                 path,
                 event_sender: channel,
                 result_channel,
@@ -100,8 +131,8 @@ impl XsTokioState {
                 let token = find_suitable_token(&self.watch_subscribers);
 
                 // Make the actual WATCH command
-                self.request_channel
-                    .send(XsMessage::from_string_slice(
+                xs_sender
+                    .send_async(XsMessage::from_string_slice(
                         XsMessageType::Watch,
                         req_id as u32,
                         &[&path, &token.0.to_string()],
@@ -109,23 +140,23 @@ impl XsTokioState {
                     ))
                     .await?;
 
-                // Wait until we got confirmation of the WATCH command by upstream.
-                *slot = Some(XsTokioTask::WatchSubscribe {
+                // Wait until we get confirmation of the WATCH command by upstream.
+                *slot = Some(XsAsyncTask::WatchSubscribe {
                     subscriber_info: WatchSubscriberInfo { channel, path },
                     result_channel,
                     token,
                 });
                 self.task_count += 1;
             }
-            XsTokioMessage::WatchUnsubscribe(token) => {
+            XsAsyncMessage::WatchUnsubscribe(token) => {
                 let Some(WatchSubscriberInfo { path, .. }) = self.watch_subscribers.get(&token.0)
                 else {
-                    bail!("Attempting unwatch without watch.");
+                    return Err(XsAsyncError::UnwatchNoWatch);
                 };
 
                 // Make the actual UNWATCH command
-                self.request_channel
-                    .send(XsMessage::from_string_slice(
+                xs_sender
+                    .send_async(XsMessage::from_string_slice(
                         XsMessageType::Unwatch,
                         req_id as u32,
                         &[path, &token.0.to_string()],
@@ -134,7 +165,7 @@ impl XsTokioState {
                     .await?;
 
                 // Wait until we got confirmation of the WATCH command by upstream.
-                *slot = Some(XsTokioTask::WatchUnsubscribe(token));
+                *slot = Some(XsAsyncTask::WatchUnsubscribe(token));
                 self.task_count += 1;
             }
         }
@@ -142,7 +173,7 @@ impl XsTokioState {
         Ok(())
     }
 
-    async fn process_response(&mut self, response: XsMessage) -> anyhow::Result<()> {
+    async fn process_response(&mut self, response: XsMessage) -> Result<(), XsAsyncError> {
         if response.msg_type == XsMessageType::WatchEvent {
             // Process a watch event (it's always req_id = 0) and is unsolicitated.
             return self.process_watch_entry(response).await;
@@ -153,21 +184,21 @@ impl XsTokioState {
 
         // Take a reference the the task slot (if any).
         let Some(slot) = self.pending_tasks.get_mut(response.request_id as usize) else {
-            bail!("Invalid req_id received")
+            return Err(XsAsyncError::InvalidRequestId);
         };
 
         // Take it (leaving None at the place).
         let Some(task) = slot.take() else {
-            bail!("No related request to this req_id")
+            return Err(XsAsyncError::UnknownRequestId);
         };
         self.task_count -= 1;
 
         match task {
-            XsTokioTask::Request(sender) => {
+            XsAsyncTask::Request(sender) => {
                 // Usual request, forward response to caller (even if it is Error variant).
                 sender.send(response).ok();
             }
-            XsTokioTask::WatchSubscribe {
+            XsAsyncTask::WatchSubscribe {
                 token,
                 result_channel,
                 subscriber_info,
@@ -196,11 +227,13 @@ impl XsTokioState {
                                 format!("Got unexpected response ({response:?})"),
                             )))
                             .ok();
-                        bail!("Got invalid response to WATCH command")
+                        return Err(XsAsyncError::InvalidResponse {
+                            expected: XsMessageType::Watch,
+                        });
                     }
                 }
             }
-            XsTokioTask::WatchUnsubscribe(token) => {
+            XsAsyncTask::WatchUnsubscribe(token) => {
                 match response.msg_type {
                     XsMessageType::Unwatch => {
                         // Make unwatch effective
@@ -208,8 +241,12 @@ impl XsTokioState {
                             warn!("Unwatched nothing");
                         }
                     }
-                    XsMessageType::Error => bail!("Unwatch failure"),
-                    _ => bail!("Got invalid response to WATCH command"),
+                    XsMessageType::Error => return Err(XsAsyncError::UnwatchFailure),
+                    _ => {
+                        return Err(XsAsyncError::InvalidResponse {
+                            expected: XsMessageType::Watch,
+                        })
+                    }
                 }
             }
         }
@@ -217,15 +254,18 @@ impl XsTokioState {
         Ok(())
     }
 
-    async fn process_watch_entry(&mut self, msg: XsMessage) -> Result<(), anyhow::Error> {
-        let [value, token] = msg.parse_payload_list()?[..] else {
-            bail!("Invalid watch event payload received")
+    async fn process_watch_entry(&mut self, message: XsMessage) -> Result<(), XsAsyncError> {
+        let [value, token] = message
+            .parse_payload_list()
+            .map_err(XsAsyncError::NonUtf8Payload)?[..]
+        else {
+            return Err(XsAsyncError::InvalidPayload);
         };
 
-        let uuid = Uuid::try_parse(token).map_err(|_| anyhow!("Got non-UUID token"))?;
+        let uuid = Uuid::try_parse(token).map_err(XsAsyncError::NonUuidToken)?;
 
-        if let Some(subscriber) = self.watch_subscribers.get(&uuid) {
-            if let Err(e) = subscriber.channel.send(value.into()).await {
+        if let Some(subscriber) = self.watch_subscribers.get_mut(&uuid) {
+            if let Err(e) = subscriber.channel.send_async(value.into()).await {
                 warn!("Lost watch subscriber: {e}");
 
                 // Subscriber is dead, remove it.
@@ -238,12 +278,17 @@ impl XsTokioState {
         Ok(())
     }
 
-    async fn run(&mut self) {
+    pub async fn run(
+        mut self,
+        message_channel: flume::Receiver<XsAsyncMessage>,
+        xs_receiver: flume::Receiver<XsMessage>,
+        xs_sender: flume::Sender<XsMessage>,
+    ) {
         loop {
             if self.task_count == MAX_REQUEST_COUNT {
                 // We can't process another task, only interface responses.
                 debug!("Too much tasks");
-                let Some(response) = self.response_channel.recv().await else {
+                let Ok(response) = xs_receiver.recv_async().await else {
                     break;
                 };
 
@@ -251,72 +296,25 @@ impl XsTokioState {
                     warn!("Process response failure: {e}")
                 }
             } else {
-                tokio::select! {
-                    Some(response) = self.response_channel.recv() => {
+                futures::select! {
+                    response = xs_receiver.recv_async() => {
+                        let Ok(response) = response else { break };
                         if let Err(e) = self.process_response(response).await {
                             warn!("Process response failure: {e}")
                         }
                     },
-                    Some(message) = self.message_receiver.recv() => {
-                        if let Err(e) = self.process_message(message).await {
+                    message = message_channel.recv_async() => {
+                        let Ok(message) = message else { break };
+                        if let Err(e) = self.process_message(message, &xs_sender).await {
                             warn!("Process message failure: {e}")
                         }
-                    }
+                    },
                     // In case we get a None, something is dead in the loop, stop here.
-                    else => break,
+                    complete => break,
                 }
             }
         }
 
         info!("Communication channel died");
     }
-}
-
-pub fn launch_xenstore_task<S>(xs_stream: S) -> mpsc::UnboundedSender<XsTokioMessage>
-where
-    S: AsyncRead + AsyncWrite + Send + 'static,
-{
-    let (mut rx, mut tx) = io::split(xs_stream);
-    let (response_tx, response_rx) = mpsc::channel(4);
-    let (request_tx, mut request_rx) = mpsc::channel(4);
-
-    // Message receiver task
-    tokio::spawn(async move {
-        while let Ok(message) = XsMessage::read_message_async(&mut rx).await {
-            debug!("< {message:?}");
-
-            if response_tx.send(message).await.is_err() {
-                break;
-            }
-        }
-
-        error!("Read message failure");
-    });
-
-    // Message sender task
-    tokio::spawn(async move {
-        while let Some(message) = request_rx.recv().await {
-            debug!("> {message:?}");
-
-            if let Err(e) = XsMessage::write_message_async(&message, &mut tx).await {
-                error!("Write message failure {e}");
-                break;
-            }
-        }
-    });
-
-    let (sender, receiver) = mpsc::unbounded_channel();
-
-    let mut state = XsTokioState {
-        pending_tasks: [const { Cell::new(None) }; MAX_REQUEST_COUNT],
-        watch_subscribers: HashMap::new(),
-        task_count: 0,
-        request_channel: request_tx,
-        response_channel: response_rx,
-        message_receiver: receiver,
-    };
-
-    tokio::spawn(async move { state.run().await });
-
-    sender
 }

--- a/src/xs_async/interface.rs
+++ b/src/xs_async/interface.rs
@@ -272,7 +272,29 @@ impl XsAsyncState {
                 self.watch_subscribers.remove(&uuid);
             }
         } else {
-            warn!("Unregistered watch message ? ({uuid})");
+            // Some kernels may misorder the watch event and watch response, try to
+            // deal with these cases by preemptively sending the event to its related
+            // channel.
+            // We lookup in pending task if any task matches the watch_event, and
+            // send the event to its dedicated channel, so we won't lose the event.
+            if let Some(channel) = self
+                .pending_tasks
+                .iter_mut()
+                .flat_map(Cell::get_mut)
+                .find_map(|task| match task {
+                    XsAsyncTask::WatchSubscribe {
+                        token,
+                        subscriber_info,
+                        ..
+                    } if token.0 == uuid => Some(subscriber_info.channel.clone()),
+                    _ => None,
+                })
+            {
+                debug!("Processing out of order watch response/event ({uuid})");
+                channel.send(value.into()).ok();
+            } else {
+                warn!("Unregistered watch message ? ({uuid})");
+            }
         }
 
         Ok(())

--- a/src/xs_async/mod.rs
+++ b/src/xs_async/mod.rs
@@ -1,0 +1,208 @@
+//! Generic async implementation.
+//!
+//! This implementation uses a underlying task to multiplex the concurrent
+//! accesses and manage watchers. If this underlying task dies (e.g dead xenstore socket),
+//! all future operations will fail with [io::ErrorKind::BrokenPipe] and all watchers
+//! will yield [None].
+
+mod interface;
+mod wire_async;
+
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::{
+    channel::oneshot,
+    io::{self, ErrorKind},
+    FutureExt, Stream,
+};
+use std::str::FromStr;
+
+use interface::{XsAsyncMessage, XsAsyncRequest, XsWatchToken};
+
+use crate::{
+    wire::{XsMessage, XsMessageType},
+    AsyncWatch, AsyncXs, AsyncXsPerm, XsPermission,
+};
+
+pub use interface::XsAsyncState;
+
+/// Generic async Xenstore implementation.
+///
+/// It can be cloned and used concurrently by multiple tasks.
+#[derive(Clone, Debug)]
+pub struct XsAsyncImpl(flume::Sender<XsAsyncMessage>);
+
+impl XsAsyncImpl {
+    pub fn new(tx: flume::Sender<XsAsyncMessage>) -> io::Result<Self> {
+        Ok(Self(tx))
+    }
+
+    async fn transmit_request(&self, request: XsMessage) -> io::Result<XsMessage> {
+        let (response_sender, response_receiver) = oneshot::channel();
+        let req_msg_type = request.msg_type;
+
+        self.0
+            .send_async(XsAsyncMessage::Request(XsAsyncRequest {
+                request,
+                response_sender,
+            }))
+            .await
+            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))?;
+
+        let response = response_receiver
+            .await
+            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))?;
+
+        match response.msg_type {
+            // Response type must match request.
+            msg_type if msg_type == req_msg_type => Ok(response),
+            XsMessageType::Error => Err(response.parse_error()),
+            msg_type => Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("Got unrelated response ({msg_type:?})"),
+            )),
+        }
+    }
+}
+
+impl AsyncXs for XsAsyncImpl {
+    async fn directory(&self, path: &str) -> io::Result<Vec<Box<str>>> {
+        let response = self
+            .transmit_request(XsMessage::from_string(XsMessageType::Directory, 0, path))
+            .await?;
+
+        Ok(response
+            .parse_payload_list()
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
+            // convert &str to Box<str>
+            .iter()
+            .map(|s| s.to_string().into_boxed_str())
+            .collect())
+    }
+
+    async fn read(&self, path: &str) -> io::Result<Box<str>> {
+        let response = self
+            .transmit_request(XsMessage::from_string(XsMessageType::Read, 0, path))
+            .await?;
+
+        Ok(response
+            .parse_payload_str()
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?
+            .unwrap_or_default()
+            // convert &str to Box<str>
+            .to_string()
+            .into_boxed_str())
+    }
+
+    async fn write(&self, path: &str, data: &str) -> io::Result<()> {
+        self.transmit_request(XsMessage::from_string_slice(
+            XsMessageType::Write,
+            0,
+            &[path, data],
+            false,
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    async fn rm(&self, path: &str) -> io::Result<()> {
+        self.transmit_request(XsMessage::from_string(XsMessageType::Rm, 0, path))
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl AsyncXsPerm for XsAsyncImpl {
+    async fn get_perms(&self, path: &str) -> io::Result<Vec<XsPermission>> {
+        let response = self
+            .transmit_request(XsMessage::from_string(XsMessageType::GetPerms, 0, path))
+            .await?;
+
+        let payloads = response
+            .parse_payload_list()
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+
+        payloads
+            .iter()
+            .map(|s| XsPermission::from_str(s).map_err(io::Error::other))
+            .collect()
+    }
+
+    async fn set_perms(&self, path: &str, perms: &[XsPermission]) -> io::Result<()> {
+        // Build a parameter list for <path>|<perm-as-string>|+?
+        let perms_strings: Vec<String> = perms.iter().map(ToString::to_string).collect();
+
+        let mut perms_str: Vec<&str> = Vec::new();
+        perms_str.reserve_exact(1 + perms.len());
+
+        perms_str.push(path);
+        perms_strings.iter().for_each(|s| perms_str.push(s));
+
+        self.transmit_request(XsMessage::from_string_slice(
+            XsMessageType::SetPerms,
+            0,
+            &perms_str,
+            true,
+        ))
+        .await?;
+
+        Ok(())
+    }
+}
+
+/// Tokio watch object.
+pub struct XsAsyncWatch {
+    event_receiver: flume::Receiver<Box<str>>,
+    async_channel: flume::Sender<XsAsyncMessage>,
+    token: XsWatchToken,
+}
+
+impl Stream for XsAsyncWatch {
+    type Item = Box<str>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let result = futures::ready!(self.event_receiver.recv_async().poll_unpin(cx));
+
+        Poll::Ready(result.ok())
+    }
+}
+
+impl Drop for XsAsyncWatch {
+    // Try to unsubscribe upstream (to not leak the watch token/state).
+    // If it fails, it means that the upper backend has died.
+    fn drop(&mut self) {
+        self.async_channel
+            .send(XsAsyncMessage::WatchUnsubscribe(self.token))
+            .ok();
+    }
+}
+
+impl AsyncWatch for XsAsyncImpl {
+    async fn watch(&self, path: &str) -> io::Result<impl Stream<Item = Box<str>> + 'static> {
+        let (event_sender, event_receiver) = flume::bounded(8);
+        let (result_channel, result_receiver) = oneshot::channel();
+
+        self.0
+            .send_async(XsAsyncMessage::WatchSubscribe {
+                path: path.to_string().into_boxed_str(),
+                event_sender,
+                result_channel,
+            })
+            .await
+            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))?;
+
+        let token = result_receiver
+            .await
+            .map_err(|e| io::Error::new(ErrorKind::BrokenPipe, e))??;
+
+        Ok(XsAsyncWatch {
+            event_receiver,
+            token,
+            async_channel: self.0.clone(),
+        })
+    }
+}

--- a/src/xs_async/wire_async.rs
+++ b/src/xs_async/wire_async.rs
@@ -1,10 +1,8 @@
 //! Some wire utilities for async.
-use std::{
-    convert::TryInto,
-    io::{ErrorKind, Read, Write},
-};
+use core::convert::TryInto;
+use std::io::{self, ErrorKind, IoSlice, Read, Write};
 
-use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::wire::{XsMessage, XENSTORE_PAYLOAD_MAX};
 
@@ -80,8 +78,9 @@ impl XsMessage {
         // len
         write_u32(&mut header_writer, self.payload.len() as u32)?;
 
-        writer.write_all(&header).await?;
-        writer.write_all(&self.payload).await?;
+        writer
+            .write_all_vectored(&mut [IoSlice::new(&header), IoSlice::new(&self.payload)])
+            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
Refactor async code into a reusable runtime-agnostic logic; also rework its error handling to use thiserror instead of anyhow.

Introduce smol runtime support (along with a dedicated example).
And add a workaround for a Linux xenbus's implementation quirk (watch event/response misordering).